### PR TITLE
Add electronics page

### DIFF
--- a/resources/js/Pages/Public/ElectronicsPage.vue
+++ b/resources/js/Pages/Public/ElectronicsPage.vue
@@ -1,0 +1,19 @@
+<template>
+  <PublicLayout>
+    <div class="max-w-6xl mx-auto p-6 space-y-6">
+      <h1 class="text-3xl font-bold text-indigo-700">Electronics</h1>
+      <div v-if="products.length" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        <ProductCard v-for="product in products" :key="product.id" :product="product" />
+      </div>
+      <p v-else class="text-gray-500">No electronics products available.</p>
+    </div>
+  </PublicLayout>
+</template>
+
+<script setup>
+import { usePage } from '@inertiajs/vue3'
+import PublicLayout from '@/Layouts/PublicLayout.vue'
+import ProductCard from '@/Components/ProductCard.vue'
+
+const products = usePage().props.products || []
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -178,6 +178,19 @@ Route::get('/flights', function () {
     return Inertia::render('Public/FlightsPage');
 });
 
+Route::get('/electronics', function () {
+    $products = \App\Models\Product::with('category', 'vendor')
+        ->whereHas('category.type', function ($query) {
+            $query->where('name', 'Electronics');
+        })
+        ->where('is_approved', true)
+        ->get();
+
+    return Inertia::render('Public/ElectronicsPage', [
+        'products' => $products,
+    ]);
+});
+
 
 
 


### PR DESCRIPTION
## Summary
- implement ElectronicsPage with product listing
- add route `/electronics` loading approved electronics products

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68458092e6c08331b3bf46e80d72ce9e