### PR TITLE
Configure Flutterwave base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,4 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+FLW_BASE_URL=https://api.flutterwave.com

--- a/app/Http/Controllers/FlutterwavePaymentController.php
+++ b/app/Http/Controllers/FlutterwavePaymentController.php
@@ -82,7 +82,7 @@ class FlutterwavePaymentController extends Controller
         ];
 
         $response = Http::withToken(config('services.flutterwave.secret_key'))
-            ->post('https://api.flutterwave.com/v3/payments', $payload);
+            ->post(config('services.flutterwave.base_url') . '/v3/payments', $payload);
 
         if ($response->successful() && $response['status'] === 'success') {
             session()->put('pending_miles', [

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -134,7 +134,7 @@ class PaymentController extends Controller
         $response = Http::withHeaders([
             'Authorization' => 'Bearer ' . env('FLUTTERWAVE_SECRET_KEY'),
             'Content-Type' => 'application/json'
-        ])->post('https://api.flutterwave.com/v3/payments', $paymentData);
+        ])->post(config('services.flutterwave.base_url') . '/v3/payments', $paymentData);
 
         if ($response->successful()) {
             $data = $response->json();
@@ -193,7 +193,7 @@ class PaymentController extends Controller
             // Verify payment with Flutterwave
             $response = Http::withHeaders([
                 'Authorization' => 'Bearer ' . env('FLUTTERWAVE_SECRET_KEY'),
-            ])->get("https://api.flutterwave.com/v3/transactions/{$transactionId}/verify");
+            ])->get(config('services.flutterwave.base_url') . "/v3/transactions/{$transactionId}/verify");
 
             if ($response->successful()) {
                 $data = $response->json();

--- a/config/services.php
+++ b/config/services.php
@@ -29,11 +29,12 @@ return [
     ],
 
     'flutterwave' => [
-    'public_key' => env('FLW_PUBLIC_KEY'),
-    'secret_key' => env('FLW_SECRET_KEY'),
-    'encryption_key' => env('FLW_ENCRYPTION_KEY'),
-    'subaccount_main' => env('FLW_SUBACCOUNT_MAIN'),
-],
+        'public_key' => env('FLW_PUBLIC_KEY'),
+        'secret_key' => env('FLW_SECRET_KEY'),
+        'encryption_key' => env('FLW_ENCRYPTION_KEY'),
+        'subaccount_main' => env('FLW_SUBACCOUNT_MAIN'),
+        'base_url' => env('FLW_BASE_URL', 'https://api.flutterwave.com'),
+    ],
 
 
     'slack' => [


### PR DESCRIPTION
## Summary
- add `base_url` option to Flutterwave config
- use the new config when building payment URLs
- document `FLW_BASE_URL` in `.env.example`

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684587f6b2e08331bbcacfe2285cf36f