### PR TITLE
Remove hardcoded Flutterwave POST call

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -165,7 +165,7 @@ class PaymentController extends Controller
             $response = Http::withHeaders([
                 'Authorization' => 'Bearer ' . env('FLUTTERWAVE_SECRET_KEY'),
                 'Content-Type' => 'application/json'
-            ])->post('https://api.flutterwave.com/v3/payments', $paymentData);
+            ])->post(config('services.flutterwave.base_url') . '/v3/payments', $paymentData);
         } catch (ConnectionException $e) {
             Log::error('Connection error while initiating payment', [
                 'booking' => $booking->booking_reference,
@@ -174,10 +174,6 @@ class PaymentController extends Controller
 
             return back()->with('error', 'Unable to connect to payment gateway. Please try again later.');
         }
-        $response = Http::withHeaders([
-            'Authorization' => 'Bearer ' . env('FLUTTERWAVE_SECRET_KEY'),
-            'Content-Type' => 'application/json'
-        ])->post(config('services.flutterwave.base_url') . '/v3/payments', $paymentData);
 
 
         if ($response->successful()) {


### PR DESCRIPTION
## Summary
- simplify PaymentController to only use the configurable Flutterwave base URL

## Testing
- `composer test` *(fails: composer not installed)*
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68459019117c8331b9b8ba9163869405